### PR TITLE
Update B_Create_STARC_Map_SHP.Rmd

### DIFF
--- a/R/B_Create_STARC_Map_SHP.Rmd
+++ b/R/B_Create_STARC_Map_SHP.Rmd
@@ -319,9 +319,6 @@ hex_shp_intersect_BLOB$road_classF <- ifelse(hex_shp_intersect_BLOB$road_class==
 
 # Categorize Road Vector File
 ```{r}
-
-hex_shp_intersect_NO_BLOB <-hex_shp_data
-
 hex_shp_intersect_NO_BLOB$row_num_N_blob  <- 1:nrow(hex_shp_intersect_NO_BLOB)# need to create additional row number column to update!!!!
 acl <- st_intersects(hex_shp_intersect_NO_BLOB$geometry,
                                  osm_data_class[osm_data_class$Road_class=="Primary",]$geometry, sparse = T)


### PR DESCRIPTION
Delete line of code that was masking the definition of hex_shp_intersect_NO_BLOB which should be hex_shp_data after filtering out all rows where hexagon units intersected with community blobs. This resulted in incorrect final road categorization of hexagon subunits as the communities were not factored into some of the road classifications